### PR TITLE
add custom init for server

### DIFF
--- a/gobigger/bin/demo_bot.py
+++ b/gobigger/bin/demo_bot.py
@@ -86,7 +86,13 @@ def demo_bot():
                     spore_radius_init=20, 
                 )
             )
-        )
+        ),
+        custom_init=dict(
+            food=[],
+            thorns=[],
+            spore=[],
+            clone=[],
+        ),
     ))
     render = EnvRender(server.map_width, server.map_height)
     server.set_render(render)

--- a/gobigger/managers/food_manager.py
+++ b/gobigger/managers/food_manager.py
@@ -43,16 +43,23 @@ class FoodManager(BaseManager):
             balls.remove()
             del self.balls[balls.name]
 
-    def spawn_ball(self):
-        position = self.border.sample()
-        size = random.uniform(self.ball_settings.radius_min, self.ball_settings.radius_max)**2
+    def spawn_ball(self, position=None, size=None):
+        if position is None:
+            position = self.border.sample()
+        if size is None:
+            size = random.uniform(self.ball_settings.radius_min, self.ball_settings.radius_max)**2
         name = uuid.uuid1()
         return FoodBall(name=name, position=position, border=self.border, size=size, **self.ball_settings)
 
-    def init_balls(self):
-        for _ in range(self.cfg.num_init):
-            ball = self.spawn_ball()
-            self.balls[ball.name] = ball
+    def init_balls(self, custom_init=None):
+        if custom_init is None:
+            for _ in range(self.cfg.num_init):
+                ball = self.spawn_ball()
+                self.balls[ball.name] = ball
+        else:
+            for ball_cfg in custom_init:
+                ball = self.spawn_ball(position=Vector2(*ball_cfg['position']), size=ball_cfg['radius']**2)
+                self.balls[ball.name] = ball
 
     def step(self, duration):
         self.refresh_time_count += duration

--- a/gobigger/managers/spore_manager.py
+++ b/gobigger/managers/spore_manager.py
@@ -36,6 +36,20 @@ class SporeManager(BaseManager):
             balls.remove()
             del self.balls[balls.name]
 
+    def spawn_ball(self, position=None, size=None):
+        if position is None:
+            position = self.border.sample()
+        if size is None:
+            size = random.uniform(self.ball_settings.radius_min, self.ball_settings.radius_max)**2
+        name = uuid.uuid1()
+        return SporeBall(name=name, position=position, border=self.border, direction=Vector2(1,0), vel_init=0)
+    
+    def init_balls(self, custom_init=None):
+        if custom_init is not None:
+            for ball_cfg in custom_init:
+                ball = self.spawn_ball(position=Vector2(*ball_cfg['position']), size=ball_cfg['radius']**2)
+                self.balls[ball.name] = ball
+
     def step(self, duration):
         return
 

--- a/gobigger/managers/thorns_manager.py
+++ b/gobigger/managers/thorns_manager.py
@@ -43,16 +43,23 @@ class ThornsManager(BaseManager):
             balls.remove()
             del self.balls[balls.name]
 
-    def spawn_ball(self):
-        position = self.border.sample()
-        size = random.uniform(self.ball_settings.radius_min, self.ball_settings.radius_max)**2
+    def spawn_ball(self, position=None, size=None):
+        if position is None:
+            position = self.border.sample()
+        if size is None:
+            size = random.uniform(self.ball_settings.radius_min, self.ball_settings.radius_max)**2
         name = uuid.uuid1()
         return ThornsBall(name=name, position=position, border=self.border, size=size, **self.ball_settings)
 
-    def init_balls(self):
-        for _ in range(self.cfg.num_init):
-            ball = self.spawn_ball()
-            self.balls[ball.name] = ball
+    def init_balls(self, custom_init=None):
+        if custom_init is None:
+            for _ in range(self.cfg.num_init):
+                ball = self.spawn_ball()
+                self.balls[ball.name] = ball
+        else:
+            for ball_cfg in custom_init:
+                ball = self.spawn_ball(position=Vector2(*ball_cfg['position']), size=ball_cfg['radius']**2)
+                self.balls[ball.name] = ball
 
     def step(self, duration):
         self.refresh_time_count += duration

--- a/gobigger/server/server.py
+++ b/gobigger/server/server.py
@@ -130,7 +130,13 @@ class Server:
                         spore_radius_init=20, 
                     )
                 )   
-            )
+            ),
+            custom_init=dict(
+                food=[], # only position and radius
+                thorns=[], # only position and radius
+                spore=[], # only position and radius
+                clone=[], # only position and radius and player and team
+            ),
         )
         return EasyDict(cfg)
 
@@ -151,6 +157,8 @@ class Server:
         self.state_tick_duration = 1 / self.state_tick_per_second
         self.action_tick_duration = 1 / self.action_tick_per_second
         self.state_tick_per_action_tick = self.state_tick_per_second // self.action_tick_per_second
+
+        self.custom_init = self.cfg.custom_init
         
         self.border = Border(0, 0, self.map_width, self.map_height)
         self.last_time = 0
@@ -169,11 +177,19 @@ class Server:
 
     def spawn_balls(self):
         '''
-        Initialize all balls
+        Overview:
+            Initialize all balls. If self.custom_init is set, initialize all balls based on it.
         '''
-        self.food_manager.init_balls() # init food
-        self.thorns_manager.init_balls() # init thorns
-        self.player_manager.init_balls() # init player
+        # check custom_init
+        custom_init_food = self.custom_init.food if self.custom_init.food else None
+        custom_init_thorns = self.custom_init.thorns if self.custom_init.thorns else None
+        custom_init_spore = self.custom_init.spore if self.custom_init.spore else None
+        custom_init_clone = self.custom_init.clone if self.custom_init.clone else None
+        # init
+        self.food_manager.init_balls(custom_init=custom_init_food) # init food
+        self.thorns_manager.init_balls(custom_init=custom_init_thorns) # init thorns
+        self.spore_manager.init_balls(custom_init=custom_init_spore) # init spore
+        self.player_manager.init_balls(custom_init=custom_init_clone) # init player
 
     def step_state_tick(self, actions=None):
         moving_balls = [] # Record all balls in motion


### PR DESCRIPTION
Users are able to customize the initialized observation in the matches. Just add `custom_init` in the config:
```
server = server(dict(
            version='0.1',
            team_num=4, 
            player_num_per_team=3, 
            map_width=1000,
            map_height=1000, 
            ...
            custom_init=dict(
                food=[{'position': [100, 100], 'radius': 2}],
                thorns=[{'position': [200, 200], 'radius': 15}],
                spore=[{'position': [300, 300], 'radius': 3}],
                clone=[{'position': [400, 400], 'radius': 12, 'player': '0', 'team': '0'}],
            ),
         ))
```
`custom_init` is the same as `overlap` in observation space. If food or thorns or spore or clone is `[]`, it will be initialized randomly.