### PR TITLE
fix SporeBall in step

### DIFF
--- a/gobigger/server/server.py
+++ b/gobigger/server/server.py
@@ -295,7 +295,7 @@ class Server:
                 elif isinstance(target_ball, SporeBall): 
                     moving_ball.eat(target_ball)
                     self.spore_manager.remove_balls(target_ball)
-            elif isinstance(moving_ball, ThornsBall):
+            elif isinstance(moving_ball, SporeBall):
                 if isinstance(target_ball, CloneBall) or isinstance(target_ball, ThornsBall): 
                     target_ball.eat(moving_ball)
                     self.spore_manager.remove_balls(moving_ball)


### PR DESCRIPTION
* [bug] fix object instance in `server.deal_with_collision()`

However, the last `elif` will not work because we don't add any `SporeBall` in `moving_balls`. But it is still necessary to leave `SporeBall` in `server.deal_with_collision()` to make it easy to add sporeball in the future.