### PR TITLE
add cheat for env render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 .pyre/
 *.mp4
 .idea/
+
+*.DS_Store

--- a/docs/en/source/tutorial/space.rst
+++ b/docs/en/source/tutorial/space.rst
@@ -206,3 +206,48 @@ The existence of a partial field of view may complicate training. Therefore, GoB
     }
 
 Please note that the corresponding ``feature_layers`` and ``overlap`` in the information of other players will be set to ``None`` except for the player with the number ``'0'``.
+
+Get global vision + player's local vision
+-------------------------------------------------
+
+In many scenarios, using some cheat information (such as removing the fog of war) can effectively help the algorithm converge. Therefore, on the basis of obtaining the global vision, we have added a mode of obtaining the global vision and the player's local vision at the same time. Get it by specifying ``cheat=True``. Note that in this mode, the setting of ``with_all_vision`` will have no effect, because the global vision information will always be returned. For example, assuming there are 2 teams in a game with 1 player in each team, the ``player_state`` obtained will be as follows:
+
+.. code-block::python
+
+    {
+        'all': {
+            'feature_layers': list(numpy.ndarray),
+            'rectangle': None,
+            'overlap': {
+                'food': [{'position': position, 'radius': radius}, ...],
+                'thorns': [{'position': position, 'radius': radius}, ...],
+                'spore': [{'position': position, 'radius': radius}, ...],
+                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...],
+            },
+            'team_name': '',
+        }
+        '0': {
+            'feature_layers': list(numpy.ndarray),
+            'rectangle': None,
+            'overlap': {
+                'food': [{'position': position, 'radius': radius}, ...],
+                'thorns': [{'position': position, 'radius': radius}, ...],
+                'spore': [{'position': position, 'radius': radius}, ...],
+                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...],
+            },
+            'team_name': team_name,
+        },
+        '1': {
+            'feature_layers': list(numpy.ndarray),
+            'rectangle': None,
+            'overlap': {
+                'food': [{'position': position, 'radius': radius}, ...],
+                'thorns': [{'position': position, 'radius': radius}, ...],
+                'spore': [{'position': position, 'radius': radius}, ...],
+                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...],
+            },
+            'team_name': team_name,
+        },
+    }
+
+Note that the global view information is placed under the ``all`` field, where the ``team_name`` is set to empty. The rest of the player information remains the same.

--- a/docs/zh_CN/source/tutorial/space.rst
+++ b/docs/zh_CN/source/tutorial/space.rst
@@ -134,6 +134,7 @@ GoBigger 定义 ``player_state`` 中的 ``feature_layers`` 为当前玩家所能
             with_spatial=True,
             with_speed=False,
             with_all_vision=False,
+            cheat=False,
         ),
     ))
 
@@ -209,3 +210,48 @@ GoBigger 定义 ``player_state`` 中的 ``feature_layers`` 为当前玩家所能
     }
 
 请注意，除了 ``'0'`` 号玩家以外，其他玩家的信息中对应的 ``feature_layers`` 和 ``overlap`` 将会置为 ``None``。
+
+获取全局视野+玩家局部视野
+------------------------------------
+
+在许多场景下，使用一些作弊信息（例如去掉战争迷雾）能够有效帮助算法收敛。因此，我们在获取全局视野的基础上，增加了同时获取全局视野和玩家局部视野的模式。通过指定 ``cheat=True`` 来获取。注意，在此模式下，``with_all_vision`` 的设置将会失效，因为会固定返回全局视野信息。例如，假设一局游戏中有 2 个队伍，每个队伍中有 1 人，那么获取到的 ``player_state`` 将会如下：
+
+.. code-block:: python
+
+    {
+        'all': {
+            'feature_layers': list(numpy.ndarray),
+            'rectangle': None,
+            'overlap': {
+                'food': [{'position': position, 'radius': radius}, ...], 
+                'thorns': [{'position': position, 'radius': radius}, ...], 
+                'spore': [{'position': position, 'radius': radius}, ...], 
+                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...], 
+            }, 
+            'team_name': '',
+        }
+        '0': {
+            'feature_layers': list(numpy.ndarray),
+            'rectangle': None,
+            'overlap': {
+                'food': [{'position': position, 'radius': radius}, ...], 
+                'thorns': [{'position': position, 'radius': radius}, ...], 
+                'spore': [{'position': position, 'radius': radius}, ...], 
+                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...], 
+            }, 
+            'team_name': team_name, 
+        },
+        '1': {
+            'feature_layers': list(numpy.ndarray),
+            'rectangle': None,
+            'overlap': {
+                'food': [{'position': position, 'radius': radius}, ...], 
+                'thorns': [{'position': position, 'radius': radius}, ...], 
+                'spore': [{'position': position, 'radius': radius}, ...], 
+                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...], 
+            }, 
+            'team_name': team_name, 
+        },
+    }
+
+请注意，全局视野信息放在了 ``all`` 字段下，其中的 ``team_name`` 被设置为空。其余玩家信息保持不变。

--- a/gobigger/render/test/test_env_render.py
+++ b/gobigger/render/test/test_env_render.py
@@ -187,4 +187,29 @@ class TestEnvRender:
             with_all_vision=False,
         )))
         _, screen_data_players = render.update_all(food_balls, thorns_balls, spore_balls, players)
-        assert screen_data_players['1']['feature_layers'] is not None        
+        assert screen_data_players['1']['feature_layers'] is not None
+
+    def test_update_all_all_cheat(self):
+        border = Border(0, 0, 15, 15)
+        render = EnvRender(width=15, height=15)
+        food_balls = [BaseBall('0', border.sample(), border=border, size=4, radius_min=2)]
+        thorns_balls = [BaseBall('0', border.sample(), border=border, size=10, radius_min=3)]
+        spore_balls = [BaseBall('0', border.sample(), border=border, size=4, radius_min=2)]
+        players = [HumanPlayer(cfg=Server.default_config().manager_settings.player_manager.ball_settings, 
+                               team_name='0', name='0', border=border, 
+                               spore_settings=Server.default_config().manager_settings.spore_manager.ball_settings),
+                   HumanPlayer(cfg=Server.default_config().manager_settings.player_manager.ball_settings, 
+                               team_name='1', name='1', border=border, 
+                               spore_settings=Server.default_config().manager_settings.spore_manager.ball_settings)]
+        players[0].respawn(position=border.sample())
+        players[1].respawn(position=border.sample())
+        render.set_obs_settings(EasyDict(dict(
+            with_spatial=True,
+            with_speed=True,
+            with_all_vision=True,
+            cheat=True,
+        )))
+        _, screen_data_players = render.update_all(food_balls, thorns_balls, spore_balls, players)
+        assert screen_data_players['all']['feature_layers'] is not None
+        assert screen_data_players['1']['feature_layers'] is not None
+

--- a/gobigger/server/server_default_config.py
+++ b/gobigger/server/server_default_config.py
@@ -85,5 +85,6 @@ server_default_config = dict(
         with_spatial=True,
         with_speed=False,
         with_all_vision=False,
+        cheat=False,
     ),
 )


### PR DESCRIPTION
Get global vision + player's local vision
-------------------------------------------------

In many scenarios, using some cheat information (such as removing the fog of war) can effectively help the algorithm converge. Therefore, on the basis of obtaining the global vision, we have added a mode of obtaining the global vision and the player's local vision at the same time. Get it by specifying ``cheat=True``. Note that in this mode, the setting of ``with_all_vision`` will have no effect, because the global vision information will always be returned. For example, assuming there are 2 teams in a game with 1 player in each team, the ``player_state`` obtained will be as follows:

.. code-block::python

    {
        'all': {
            'feature_layers': list(numpy.ndarray),
            'rectangle': None,
            'overlap': {
                'food': [{'position': position, 'radius': radius}, ...],
                'thorns': [{'position': position, 'radius': radius}, ...],
                'spore': [{'position': position, 'radius': radius}, ...],
                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...],
            },
            'team_name': '',
        }
        '0': {
            'feature_layers': list(numpy.ndarray),
            'rectangle': None,
            'overlap': {
                'food': [{'position': position, 'radius': radius}, ...],
                'thorns': [{'position': position, 'radius': radius}, ...],
                'spore': [{'position': position, 'radius': radius}, ...],
                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...],
            },
            'team_name': team_name,
        },
        '1': {
            'feature_layers': list(numpy.ndarray),
            'rectangle': None,
            'overlap': {
                'food': [{'position': position, 'radius': radius}, ...],
                'thorns': [{'position': position, 'radius': radius}, ...],
                'spore': [{'position': position, 'radius': radius}, ...],
                'clone': [{'position': position, 'radius': radius, 'player': player_name, 'team': team_name}, ...],
            },
            'team_name': team_name,
        },
    }

Note that the global view information is placed under the ``all`` field, where the ``team_name`` is set to empty. The rest of the player information remains the same.